### PR TITLE
Rename FUserData to FAccountUserData.

### DIFF
--- a/Documentation/tutorial.md
+++ b/Documentation/tutorial.md
@@ -138,7 +138,7 @@ const FString Country = TEXT("US");
 const FString DateOfBirth = TEXT("2000-12-20");
 bool bUserAccountCreated = false;
 
-FRegistry::User.Register(OriginalEmail, Password, DisplayName, Country, DateOfBirth, THandler<FUserData>::CreateLambda([&bUserAccountCreated](const FUserData& Result)
+FRegistry::User.Register(OriginalEmail, Password, DisplayName, Country, DateOfBirth, THandler<FAccountUserData>::CreateLambda([&bUserAccountCreated](const FAccountUserData& Result)
     {
         UE_LOG(LogAccelByteUserTest, Display, TEXT("Success."));
         bUserAccountCreated = true;
@@ -154,8 +154,8 @@ This function will get data of currently logged in user.
 
 ```cpp
 bool bGetDataSuccessful1 = false;
-FUserData GetDataResult;
-FRegistry::User.GetData(THandler<FUserData>::CreateLambda([&](const FUserData& Result) 
+FAccountUserData GetDataResult;
+FRegistry::User.GetData(THandler<FAccountUserData>::CreateLambda([&](const FAccountUserData& Result) 
     {
         UE_LOG(LogAccelByteUserTest, Log, TEXT("Success"));
         bGetDataSuccessful = true;
@@ -178,10 +178,10 @@ FUserUpdateRequest UpdateRequest
         FString(UpdatedEmail),
         FString()
     };
-FUserData UpdateResult;
+FAccountUserData UpdateResult;
 bool bUserUpdated = false;
 
-FRegistry::User.Update(UpdateRequest, THandler<FUserData>::CreateLambda([&](const FUserData& Result)
+FRegistry::User.Update(UpdateRequest, THandler<FAccountUserData>::CreateLambda([&](const FAccountUserData& Result)
     {
         UE_LOG(LogAccelByteUserTest, Display, TEXT("Success."));
         bUserUpdated = true;
@@ -203,7 +203,7 @@ FString Email = TEXT("testSDK@game.test");
 FString Password = TEXT("password");
 bool bUpgradeSuccessful = false;
 
-FRegistry::User.Upgrade(Email, Password, THandler<FUserData>::CreateLambda([&](const FUserData& Result)
+FRegistry::User.Upgrade(Email, Password, THandler<FAccountUserData>::CreateLambda([&](const FAccountUserData& Result)
     {
         UE_LOG(LogAccelByteUserTest, Log, TEXT("Success"));
         bUpgradeSuccessful = true;
@@ -238,7 +238,7 @@ This function will verify the registered email **after** user receives verificat
 bool bGetVerificationCode = false;
 FString VerificationCode = GetVerificationCodeFromUserId(FRegistry::Credentials.GetUserId());
 
-FRegistry::User.Verify(VerificationCode, THandler<FUserData>::CreateLambda([&](const FUserData& Result)
+FRegistry::User.Verify(VerificationCode, THandler<FAccountUserData>::CreateLambda([&](const FAccountUserData& Result)
     {
         UE_LOG(LogAccelByteUserTest, Log, TEXT("Success"));
         bGetVerificationCode = true;
@@ -314,7 +314,7 @@ FString Password = TEXT("password");
 bool bGetVerificationCode = false;
 FString VerificationCode = GetVerificationCodeFromUserId(FRegistry::Credentials.GetUserId());
 
-FRegistry::User.UpgradeAndVerify(Email, Password, VerificationCode, THandler<FUserData>::CreateLambda([&](const FUserData& Result)
+FRegistry::User.UpgradeAndVerify(Email, Password, VerificationCode, THandler<FAccountUserData>::CreateLambda([&](const FAccountUserData& Result)
     {
         UE_LOG(LogAccelByteUserTest, Log, TEXT("Success"));
         bGetVerificationCode = true;

--- a/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Private/Api/AccelByteUserApi.cpp
+++ b/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Private/Api/AccelByteUserApi.cpp
@@ -89,7 +89,7 @@ void User::LoginWithOtherPlatform(EAccelBytePlatformType PlatformType, const FSt
 	{
 		const FOauth2Session session = Result;
 		AccelByte::Api::User::Credentials.SetUserSession(session.Session_id, FPlatformTime::Seconds() + (session.Expires_in*FMath::FRandRange(0.7, 0.9)), session.Refresh_id);
-		GetData(THandler<FUserData>::CreateLambda([this, OnSuccess, session](const FUserData& Result)
+		GetData(THandler<FAccountUserData>::CreateLambda([this, OnSuccess, session](const FAccountUserData& Result)
 		{
 			AccelByte::Api::User::Credentials.SetUserLogin(Result.UserId, Result.DisplayName, Result.Namespace);
 			OnSuccess.ExecuteIfBound();
@@ -121,7 +121,7 @@ void User::LoginWithUsername(const FString& Username, const FString& Password, c
 	{
 		const FOauth2Session session = Result;
 		AccelByte::Api::User::Credentials.SetUserSession(session.Session_id, FPlatformTime::Seconds() + (session.Expires_in*FMath::FRandRange(0.7, 0.9)), session.Refresh_id);
-		GetData(THandler<FUserData>::CreateLambda([this, OnSuccess, session](const FUserData& Result)
+		GetData(THandler<FAccountUserData>::CreateLambda([this, OnSuccess, session](const FAccountUserData& Result)
 		{
 			AccelByte::Api::User::Credentials.SetUserLogin(Result.UserId, Result.DisplayName, Result.Namespace);
 			OnSuccess.ExecuteIfBound();
@@ -152,7 +152,7 @@ void User::LoginWithDeviceId(const FVoidHandler& OnSuccess, const FErrorHandler&
 	{
 		const FOauth2Session session = Result;
 		AccelByte::Api::User::Credentials.SetUserSession(session.Session_id, FPlatformTime::Seconds() + (session.Expires_in*FMath::FRandRange(0.7, 0.9)), session.Refresh_id);
-		GetData(THandler<FUserData>::CreateLambda([this, OnSuccess, session](const FUserData& Result)
+		GetData(THandler<FAccountUserData>::CreateLambda([this, OnSuccess, session](const FAccountUserData& Result)
 		{
 			AccelByte::Api::User::Credentials.SetUserLogin(Result.UserId, Result.DisplayName, Result.Namespace);
 			OnSuccess.ExecuteIfBound();
@@ -185,7 +185,7 @@ void User::LoginWithLauncher(const FVoidHandler& OnSuccess, const FErrorHandler 
 	Oauth2::GetSessionIdWithAuthorizationCodeGrant(Settings.ClientId, Settings.ClientSecret, AuthorizationCode, Settings.RedirectURI, THandler<FOauth2Session>::CreateLambda([this, OnSuccess, OnError](const FOauth2Session& Result) {
 		const FOauth2Session session = Result;
 		AccelByte::Api::User::Credentials.SetUserSession(session.Session_id, FPlatformTime::Seconds() + (session.Expires_in*FMath::FRandRange(0.7, 0.9)), session.Refresh_id);
-		GetData(THandler<FUserData>::CreateLambda([this, OnSuccess, session](const FUserData& Result)
+		GetData(THandler<FAccountUserData>::CreateLambda([this, OnSuccess, session](const FAccountUserData& Result)
 		{
 			AccelByte::Api::User::Credentials.SetUserLogin(Result.UserId, Result.DisplayName, Result.Namespace);
 			OnSuccess.ExecuteIfBound();
@@ -268,7 +268,7 @@ void User::Registerv2(const FString& EmailAddress, const FString& Username, cons
 	FRegistry::HttpRetryScheduler.ProcessRequest(Request, CreateHttpResultHandler(OnSuccess, OnError), FPlatformTime::Seconds());
 }
 
-void User::GetData(const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError)
+void User::GetData(const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError)
 {
 	Report report;
 	report.GetFunctionLog(FString(__FUNCTION__));
@@ -291,7 +291,7 @@ void User::GetData(const THandler<FUserData>& OnSuccess, const FErrorHandler& On
 	FRegistry::HttpRetryScheduler.ProcessRequest(Request, CreateHttpResultHandler(OnSuccess, OnError), FPlatformTime::Seconds());
 }
 
-void User::UpdateUser(FUserUpdateRequest UpdateRequest, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError)
+void User::UpdateUser(FUserUpdateRequest UpdateRequest, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError)
 {
 	Report report;
 	report.GetFunctionLog(FString(__FUNCTION__));
@@ -372,7 +372,7 @@ void User::SendUpgradeVerificationCode(const FString& Username, const FVoidHandl
 	SendVerificationCode(SendUpgradeVerificationCodeRequest, OnSuccess, OnError);
 }
 
-void User::UpgradeAndVerify(const FString& Username, const FString& Password, const FString& VerificationCode, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError)
+void User::UpgradeAndVerify(const FString& Username, const FString& Password, const FString& VerificationCode, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError)
 {
 	Report report;
 	report.GetFunctionLog(FString(__FUNCTION__));
@@ -395,8 +395,8 @@ void User::UpgradeAndVerify(const FString& Username, const FString& Password, co
 	FRegistry::HttpRetryScheduler.ProcessRequest(
 		Request,
 		CreateHttpResultHandler(
-			THandler<FUserData>::CreateLambda(
-				[OnSuccess](const FUserData& UserData)
+			THandler<FAccountUserData>::CreateLambda(
+				[OnSuccess](const FAccountUserData& UserData)
 				{
 					OnSuccess.ExecuteIfBound(UserData);
 				}),
@@ -404,7 +404,7 @@ void User::UpgradeAndVerify(const FString& Username, const FString& Password, co
 		FPlatformTime::Seconds());
 }
 
-void User::Upgrade(const FString& Username, const FString& Password, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError)
+void User::Upgrade(const FString& Username, const FString& Password, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError)
 {
 	Report report;
 	report.GetFunctionLog(FString(__FUNCTION__));
@@ -427,8 +427,8 @@ void User::Upgrade(const FString& Username, const FString& Password, const THand
 	FRegistry::HttpRetryScheduler.ProcessRequest(
 		Request,
 		CreateHttpResultHandler(
-			THandler<FUserData>::CreateLambda(
-				[OnSuccess](const FUserData& UserData)
+			THandler<FAccountUserData>::CreateLambda(
+				[OnSuccess](const FAccountUserData& UserData)
 				{
 					OnSuccess.ExecuteIfBound(UserData);
 				}),
@@ -436,7 +436,7 @@ void User::Upgrade(const FString& Username, const FString& Password, const THand
 		FPlatformTime::Seconds());
 }
 
-void User::Upgradev2(const FString& EmailAddress, const FString& Username, const FString& Password, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError)
+void User::Upgradev2(const FString& EmailAddress, const FString& Username, const FString& Password, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError)
 {
 	Report report;
 	report.GetFunctionLog(FString(__FUNCTION__));
@@ -459,8 +459,8 @@ void User::Upgradev2(const FString& EmailAddress, const FString& Username, const
 	FRegistry::HttpRetryScheduler.ProcessRequest(
 		Request,
 		CreateHttpResultHandler(
-			THandler<FUserData>::CreateLambda(
-				[OnSuccess](const FUserData& UserData)
+			THandler<FAccountUserData>::CreateLambda(
+				[OnSuccess](const FAccountUserData& UserData)
 				{
 					OnSuccess.ExecuteIfBound(UserData);
 				}),
@@ -757,7 +757,7 @@ void User::SearchUsers(const FString& Query, const THandler<FPagedPublicUsersInf
 	SearchUsers(Query, EAccelByteSearchType::ALL, OnSuccess, OnError);
 }
 
-void User::GetUserByUserId(const FString& UserID, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError)
+void User::GetUserByUserId(const FString& UserID, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError)
 {
 	Report report;
 	report.GetFunctionLog(FString(__FUNCTION__));
@@ -778,7 +778,7 @@ void User::GetUserByUserId(const FString& UserID, const THandler<FUserData>& OnS
 	FRegistry::HttpRetryScheduler.ProcessRequest(Request, CreateHttpResultHandler(OnSuccess, OnError), FPlatformTime::Seconds());
 }
 
-void User::GetUserByOtherPlatformUserId(EAccelBytePlatformType PlatformType, const FString& OtherPlatformUserId, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError)
+void User::GetUserByOtherPlatformUserId(EAccelBytePlatformType PlatformType, const FString& OtherPlatformUserId, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError)
 {
 	Report report;
 	report.GetFunctionLog(FString(__FUNCTION__));

--- a/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Private/Blueprints/AccelByteUserBlueprints.cpp
+++ b/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Private/Blueprints/AccelByteUserBlueprints.cpp
@@ -66,7 +66,7 @@ void UBPUser::Upgrade(const FString& Username, const FString& Password, const FD
 {
 	FRegistry::User.Upgrade(
 		Username, Password,
-		THandler<FUserData>::CreateLambda([OnSuccess](const FUserData& Result) { OnSuccess.ExecuteIfBound(Result); }),
+		THandler<FAccountUserData>::CreateLambda([OnSuccess](const FAccountUserData& Result) { OnSuccess.ExecuteIfBound(Result); }),
 		FErrorHandler::CreateLambda([OnError](int32 ErrorCode, const FString& ErrorMessage) { OnError.ExecuteIfBound(ErrorCode, ErrorMessage); })
 	);
 }
@@ -84,7 +84,7 @@ void UBPUser::UpgradeAndVerify(const FString& Username, const FString& Password,
 {
 	FRegistry::User.UpgradeAndVerify(
 		Username, Password, VerificationCode,
-		THandler<FUserData>::CreateLambda([OnSuccess](const FUserData& Result) { OnSuccess.ExecuteIfBound(Result); }),
+		THandler<FAccountUserData>::CreateLambda([OnSuccess](const FAccountUserData& Result) { OnSuccess.ExecuteIfBound(Result); }),
 		FErrorHandler::CreateLambda([OnError](int32 ErrorCode, const FString& ErrorMessage) { OnError.ExecuteIfBound(ErrorCode, ErrorMessage); })
 	);
 }

--- a/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Api/AccelByteUserApi.h
+++ b/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Api/AccelByteUserApi.h
@@ -84,7 +84,7 @@ namespace AccelByte
 			 * @param DisplayName The DisplayName.
 			 * @param Country User's country, ISO3166-1 alpha-2 two letter, e.g. US.
 			 * @param DateOfBirth User's date of birth, valid values are between 1905-01-01 until current date.
-			 * @param OnSuccess This will be called when the operation succeeded. The result is FUserData.
+			 * @param OnSuccess This will be called when the operation succeeded. The result is FAccountUserData.
 			 * @param OnError This will be called when the operation failed.
 			 */
 			void Register(const FString& Username, const FString& Password, const FString& DisplayName, const FString& Country, const FString& DateOfBirth, const THandler<FRegisterResponse>& OnSuccess, const FErrorHandler& OnError);
@@ -98,7 +98,7 @@ namespace AccelByte
 			 * @param DisplayName The DisplayName.
 			 * @param Country User's country, ISO3166-1 alpha-2 two letter, e.g. US.
 			 * @param DateOfBirth User's date of birth, valid values are between 1905-01-01 until current date.
-			 * @param OnSuccess This will be called when the operation succeeded. The result is FUserData.
+			 * @param OnSuccess This will be called when the operation succeeded. The result is FAccountUserData.
 			 * @param OnError This will be called when the operation failed.
 			 */
 			void Registerv2(const FString& EmailAddress, const FString& Username, const FString& Password, const FString& DisplayName, const FString& Country, const FString& DateOfBirth, const THandler<FRegisterResponse>& OnSuccess, const FErrorHandler& OnError);
@@ -106,10 +106,10 @@ namespace AccelByte
 			/**
 			 * @brief This function will get data of currently logged in user.
 			 *
-			 * @param OnSuccess This will be called when the operation succeeded. The result is FUserData.
+			 * @param OnSuccess This will be called when the operation succeeded. The result is FAccountUserData.
 			 * @param OnError This will be called when the operation failed.
 			 */
-			void GetData(const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError);
+			void GetData(const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError);
 
 			/**
 			 * @brief This function will upgrade user's headless account. You may call SendUserAccountVerificationCode afterwards.
@@ -122,7 +122,7 @@ namespace AccelByte
 			 * @param OnSuccess This will be called when the operation succeeded.
 			 * @param OnError This will be called when the operation failed.
 			 */
-			void Upgrade(const FString& Username, const FString& Password, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError);
+			void Upgrade(const FString& Username, const FString& Password, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError);
 
 			/**
 			 * @brief This function will upgrade user's headless account. You may call SendUserAccountVerificationCode afterwards.
@@ -136,7 +136,7 @@ namespace AccelByte
 			 * @param OnSuccess This will be called when the operation succeeded.
 			 * @param OnError This will be called when the operation failed.
 			 */
-			void Upgradev2(const FString& EmailAddress, const FString& Username, const FString& Password, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError);
+			void Upgradev2(const FString& EmailAddress, const FString& Username, const FString& Password, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError);
 
 			/**
 			 * @brief This function will upgrade user's headless account. You may call SendUserAccountVerificationCode afterwards.
@@ -205,7 +205,7 @@ namespace AccelByte
 			 * @param OnSuccess This will be called when the operation succeeded.
 			 * @param OnError This will be called when the operation failed.
 			 */
-			void UpgradeAndVerify(const FString& Username, const FString& Password, const FString& VerificationCode, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError);
+			void UpgradeAndVerify(const FString& Username, const FString& Password, const FString& VerificationCode, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError);
 
 			/**
 			 * @brief This function gets user's platform accounts linked to user’s account.
@@ -273,29 +273,29 @@ namespace AccelByte
 			 * @brief This function will search user by userId.
 			 *
 			 * @param UserId Targeted user's ID.
-			 * @param OnSuccess This will be called when the operation succeeded. The result is FUserData.
+			 * @param OnSuccess This will be called when the operation succeeded. The result is FAccountUserData.
 			 * @param OnError This will be called when the operation failed.
 			 */
-			void GetUserByUserId(const FString& UserId, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError);
+			void GetUserByUserId(const FString& UserId, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError);
 
 			/**
 			 * @brief This function will get user by other platform user id it linked to.
 			 *
 			 * @param PlatformType Other platform type .
 			 * @param OtherPlatformUserId Targeted user's ID.
-			 * @param OnSuccess This will be called when the operation succeeded. The result is FUserData.
+			 * @param OnSuccess This will be called when the operation succeeded. The result is FAccountUserData.
 			 * @param OnError This will be called when the operation failed.
 			 */
-			void GetUserByOtherPlatformUserId(EAccelBytePlatformType PlatformType, const FString& OtherPlatformUserId, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError);
+			void GetUserByOtherPlatformUserId(EAccelBytePlatformType PlatformType, const FString& OtherPlatformUserId, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError);
 
 			/**
 			 * @brief This function for update user account info within the game.
 			 *
 			 * @param UpdateRequest The data you want to update. for DateOfBirth, the format is YYYY-MM-DD.
-			 * @param OnSuccess This will be called when the operation succeeded. The result is FUserData.
+			 * @param OnSuccess This will be called when the operation succeeded. The result is FAccountUserData.
 			 * @param OnError This will be called when the operation failed.
 			 */
-			void UpdateUser(FUserUpdateRequest UpdateRequest, const THandler<FUserData>& OnSuccess, const FErrorHandler& OnError);
+			void UpdateUser(FUserUpdateRequest UpdateRequest, const THandler<FAccountUserData>& OnSuccess, const FErrorHandler& OnError);
 
 			/**
 			 * @brief This function will get user(s) by other platform user id(s) it linked to.

--- a/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Blueprints/AccelByteUserBlueprints.h
+++ b/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Blueprints/AccelByteUserBlueprints.h
@@ -10,7 +10,7 @@
 #include "AccelByteUe4Sdk/Public/Models/AccelByteUserModels.h"
 #include "AccelByteUserBlueprints.generated.h"
 
-DECLARE_DYNAMIC_DELEGATE_OneParam(FDUserDataHandler, const FUserData&, Result);
+DECLARE_DYNAMIC_DELEGATE_OneParam(FDUserDataHandler, const FAccountUserData&, Result);
 DECLARE_DYNAMIC_DELEGATE_OneParam(FDUserRegisterHandler, const FRegisterResponse&, Result);
 DECLARE_DYNAMIC_DELEGATE_OneParam(FDPlatformLinksHandler, const FPagedPlatformLinks&, PlatformLinks);
 DECLARE_DYNAMIC_DELEGATE_OneParam(FDUserEligiblePlayHandler, const bool, Result);

--- a/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Models/AccelByteUserModels.h
+++ b/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Models/AccelByteUserModels.h
@@ -141,54 +141,54 @@ struct ACCELBYTEUE4SDK_API FPermission
 };
 
 USTRUCT(BlueprintType)
-struct ACCELBYTEUE4SDK_API FUserData
+struct ACCELBYTEUE4SDK_API FAccountUserData
 {
 	GENERATED_BODY()
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString AuthType;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		TArray<FBan> Bans;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString Country;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString CreatedAt;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString DateOfBirth;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		bool DeletionStatus;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString DisplayName;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString EmailAddress; //optional
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		bool EmailVerified;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		bool Enabled;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString LastDateOfBirthChangedTime;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString LastEnabledChangedTime;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString Namespace;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString NewEmailAddress; //optional
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString OldEmailAddress;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		TArray<FPermission> Permissions;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString PhoneNumber; //optional
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		bool PhoneVerified;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString PlatformId; //optional
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString PlatformUserId; //optional
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		TArray<FString> Roles;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString UserId;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | UserUpdateRespone")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AccelByte | UserProfile | Models | AccountUserData")
 		FString Username; //optional
 };
 


### PR DESCRIPTION
Renamed FUserData to FAccountUserData to avoid collision with Unreal
4.26. In UE4.26, a define of "FUserData" is created to handle different
  physics types and it is not held under a namespace. This creates a
  collision based on the name of the struct.