### PR TITLE
Fixed version references.

### DIFF
--- a/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Core/AccelByteError.h
+++ b/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Core/AccelByteError.h
@@ -33,7 +33,7 @@ struct ACCELBYTEUE4SDK_API FErrorInfo
 
 namespace AccelByte
 {
-#if ENGINE_MINOR_VERSION > 25
+#if ENGINE_MINOR_VERSION >= 26
 	template <typename T> using THandler = TDelegate<void(const T&)>;
 	using FVoidHandler = TDelegate<void()>;
 	using FErrorHandler = TDelegate<void(int32 /*ErrorCode*/, const FString& /* ErrorMessage */)>;

--- a/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Models/AccelByteUserModels.h
+++ b/Plugins/AccelByteUe4Sdk/Source/AccelByteUe4Sdk/Public/Models/AccelByteUserModels.h
@@ -6,6 +6,7 @@
 
 #include "CoreMinimal.h"
 #include "AccelByteGeneralModels.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "AccelByteUserModels.generated.h"
 
 UENUM(BlueprintType)


### PR DESCRIPTION
Added missing include to define ENGINE_MINOR_VERSION preprocessor macro.
Updated version check to specifically check for 4.26.